### PR TITLE
Fix GitHub Pages deployment with correct base URL

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -34,6 +34,8 @@ jobs:
     
     - name: Build client
       run: npm run build
+      env:
+        GITHUB_PAGES: true
     
     - name: Setup Pages
       if: github.ref == 'refs/heads/main'

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -18,6 +18,7 @@ export default defineConfig({
         ]
       : []),
   ],
+  base: process.env.GITHUB_PAGES === "true" ? "/FamilyListPro/" : "/",
   resolve: {
     alias: {
       "@": path.resolve(import.meta.dirname, "client", "src"),


### PR DESCRIPTION
## Summary
Fixes 404 errors when accessing the deployed GitHub Pages site by configuring the correct base URL for asset loading.

## Problem
GitHub Pages serves sites at `https://username.github.io/repository-name/` but Vite was building assets with root `/` paths, causing all CSS/JS files to 404.

## Solution
- Added `base` configuration to `vite.config.ts` that sets `/FamilyListPro/` when `GITHUB_PAGES=true`
- Updated GitHub Actions workflow to set `GITHUB_PAGES=true` during build
- Local development continues to work normally with root `/` path

## Changes
- **vite.config.ts**: Added conditional base URL based on `GITHUB_PAGES` environment variable
- **.github/workflows/deploy.yml**: Added environment variable to build step

## Test Results
✅ Local build works: `npm run build` → assets use `/` paths  
✅ GitHub Pages build works: `GITHUB_PAGES=true npm run build` → assets use `/FamilyListPro/` paths

The deployed site should now load correctly without 404s.

🤖 Generated with [Claude Code](https://claude.ai/code)